### PR TITLE
Fix Issue #2

### DIFF
--- a/language/en_UK/plugin.lang.php
+++ b/language/en_UK/plugin.lang.php
@@ -18,17 +18,17 @@ $lang['Display a mark on thumbnails list'] = 'Display a mark on thumbnails list'
 
 $lang['Seperate the two labels with the | symbol. Leave blank to use default translation.'] = 'Separate the two labels with the | symbol. Leave blank to use default translation.';
 
-$lang['This picture is a backside...'] = 'This picture is a backside...';
-$lang['...of the picture n°'] = '...of the picture n°';
-$lang['Backside management'] = 'Backside management';
-$lang['Hide backside from albums'] = 'Hide backside from albums';
-$lang['This picture has a backside :'] = 'This picture has a backside: ';
+$lang['This picture is a backside...'] = 'This image is a backside...';
+$lang['...of the picture n°'] = 'of image id: ';
+$lang['Backside management'] = 'Backside Management';
+$lang['Hide backside from albums'] = 'Hide backside image from albums';
+$lang['This picture has a backside :'] = 'This image has backside image id: ';
 
-$lang['Backside and frontside can\'t be the same picture'] = 'Backside and frontside can\'t be the same picture';
-$lang['The picture n°%d has already a backside : %s'] = 'The picture n°%d has already a backside: %s';
-$lang['The picture n°%s is already a backside'] = 'The picture n°%s is already a backside';
-$lang['This picture is now the backside of the picture n°%s'] = 'This picture is now the backside of the picture n°%s';
-$lang['Unknown id %d for frontside picture'] = 'Unknown id %d for frontside picture';
-$lang['This picture is no longer a backside'] = 'This picture is no longer a backside';
+$lang['Backside and frontside can\'t be the same picture'] = 'Backside and frontside images can\'t be the same';
+$lang['The picture n°%d has already a backside : %s'] = 'Image id=%d already has a backside: %s';
+$lang['The picture n°%s is already a backside'] = 'Image id=%s is already a backside';
+$lang['This picture is now the backside of the picture n°%s'] = 'This image is now the backside of image id = %s';
+$lang['Unknown id %d for frontside picture'] = 'Unknown image id %d for frontside image';
+$lang['This picture is no longer a backside'] = 'This image is no longer a backside';
 
 ?>

--- a/pem_metadata.txt
+++ b/pem_metadata.txt
@@ -1,0 +1,4 @@
+File automatically created from SVN or Git repository.
+
+URL: https://github.com/Piwigo/Piwigo-Back2Front 
+Revision: b65e92aca1f2ac414a2cfdc0472a5d42e93ce87b (Tue Nov 30 15:07:57 2021 +0100)

--- a/template/picture_modify.tpl
+++ b/template/picture_modify.tpl
@@ -22,18 +22,18 @@ $(document).ready(function () {ldelim}
   {else}
     <table style="min-width:400px;">
       <tr>
+	<td><input type="checkbox" name="b2f_is_verso" {if isset($B2F_IS_VERSO)}{$B2F_IS_VERSO}"{/if}></td>
         <td><b>{'This picture is a backside...'|@translate}</b></td>
-        <td style="width:70px"><input type="checkbox" name="b2f_is_verso" {$B2F_IS_VERSO}></td>
       </tr>
       
       <tr class="frontside_param" {if !isset($B2F_IS_VERSO)}style="display:none;"{/if}>
-        <td><b>{'...of the picture n°'|@translate}</b></td>
-        <td><input type="text" size="4" name="b2f_front_id" value="{$B2F_FRONT_ID}"></td>
+        <td></td>
+        <td><b>{'...of the picture n°'|@translate}</b><input type="text" size="4" name="b2f_front_id" value="{$B2F_FRONT_ID}"></td>
       </tr>
       
       <tr class="frontside_param" {if !isset($B2F_IS_VERSO)}style="display:none;"{/if}>
-        <td><b>{'Hide backside from albums'|@translate}</b></td>
         <td><input type="checkbox" name="b2f_move_verso" {$B2F_MOVE_VERSO}></td>
+        <td><b>{'Hide backside from albums'|@translate}</b></td>
       </tr>
     </table>
 


### PR DESCRIPTION
Fixed by viosca (https://github.com/Piwigo/Piwigo-Back2Front/pull/3):
PHP Warnings due to initialized template variable. Cleaned up english lang translations. Modified Maintenance mode to put checks before actions. Some logic in had to be modified to prevent empty/corrupt fields, etc.